### PR TITLE
Feat/refresh token

### DIFF
--- a/src/main/java/edu/ntnu/fullstack/prosjekt/quizzer/controllers/TokenController.java
+++ b/src/main/java/edu/ntnu/fullstack/prosjekt/quizzer/controllers/TokenController.java
@@ -4,11 +4,14 @@ package edu.ntnu.fullstack.prosjekt.quizzer.controllers;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import edu.ntnu.fullstack.prosjekt.quizzer.domain.dto.LoginDto;
-import edu.ntnu.fullstack.prosjekt.quizzer.domain.dto.TokenDto;
 import edu.ntnu.fullstack.prosjekt.quizzer.services.UserService;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,50 +36,93 @@ public class TokenController {
   // keyStr is hardcoded here for testing purpose
   // in a real scenario, it should either be stored in a database or injected from the environment
   public static final String keyStr = "changemeinprod";
-  private static final Duration JWT_TOKEN_VALIDITY = Duration.ofMinutes(5);
+  private static final Duration JWT_ACCESS_TOKEN_VALIDITY = Duration.ofMinutes(10);
+  private static final Duration JWT_REFRESH_TOKEN_VALIDITY = Duration.ofDays(30);
 
   private UserService userService;
 
 
+  /**
+   * Endpoint for generating a pair of access and refresh tokens.
+   *
+   * @param userService the user who is getting the tokens.
+   */
   public TokenController(UserService userService) {
     this.userService = userService;
   }
-
-  /**
-   * Generates an authentication token (JWT) for users.
-   *
-   * @param loginRequest A dto representing the login attempt from a user.
-   * @return A JWT used to authenticate the user.
-   * @throws Exception Throws an exception if the request is denied.
-   */
   @PostMapping()
   @ResponseStatus(value = HttpStatus.CREATED)
-  public ResponseEntity<TokenDto> generateToken(final @RequestBody LoginDto loginRequest) throws Exception {
-    // if username and password are valid, issue an access token
-
+  public ResponseEntity<Map<String, String>> authenticateUser(final @RequestBody LoginDto loginRequest) throws Exception {
     if (userService.checkCredentials(loginRequest)) {
-      return new ResponseEntity<>(new TokenDto(generateToken(loginRequest.getUsername())), HttpStatus.OK);
+      String accessToken = generateAccessToken(loginRequest.getUsername());
+      String refreshToken = generateRefreshToken(loginRequest.getUsername());
+      Map<String, String> tokens = new HashMap<>();
+      tokens.put("accessToken", accessToken);
+      tokens.put("refreshToken", refreshToken);
+      return new ResponseEntity<>(tokens, HttpStatus.OK);
     }
-
-    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED,
-            "Access denied, wrong credentials...");
+    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Access denied, wrong credentials...");
   }
 
   /**
-   * Method used to generate a valid jwt.
+   * Endpoint for refreshing an access token with a valid refresh token.
    *
-   * @param userId Unique identifier (username) for the user that receives the token.
-   * @return A String containing the authentication token.
+   * @param refreshToken the refresh token for the user.
+   * @return the new token.
    */
-  public String generateToken(final String userId) {
+  @PostMapping("/refresh")
+  public ResponseEntity<Map<String, String>> refreshAccessToken(@RequestBody String refreshToken) {
+    try {
+      Algorithm algorithm = Algorithm.HMAC512(keyStr);
+      JWTVerifier verifier = JWT.require(algorithm)
+          .withIssuer("QuizzerBackend")
+          .build();
+      DecodedJWT jwt = verifier.verify(refreshToken);
+      String userId = jwt.getSubject();
+
+      // Generate new tokens
+      String newAccessToken = generateAccessToken(userId);
+
+      Map<String, String> tokens = new HashMap<>();
+      tokens.put("accessToken", newAccessToken);
+
+      return ResponseEntity.ok(tokens);
+    } catch (JWTVerificationException exception){
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid refresh token");
+    }
+  }
+
+  /**
+   * Generates access token
+   *
+   * @param userId the user who wants to generate a token.
+   * @return the token.
+   */
+  public String generateAccessToken(final String userId) {
     final Instant now = Instant.now();
     final Algorithm hmac512 = Algorithm.HMAC512(keyStr);
-    final JWTVerifier verifier = JWT.require(hmac512).build();
     return JWT.create()
         .withSubject(userId)
         .withIssuer("QuizzerBackend")
         .withIssuedAt(now)
-        .withExpiresAt(now.plusMillis(JWT_TOKEN_VALIDITY.toMillis()))
+        .withExpiresAt(now.plusMillis(JWT_ACCESS_TOKEN_VALIDITY.toMillis()))
+        .sign(hmac512);
+  }
+
+  /**
+   * Generates a refresh token.
+   *
+   * @param userId the user who wants to generate a token.
+   * @return the token.
+   */
+  public String generateRefreshToken(final String userId) {
+    final Instant now = Instant.now();
+    final Algorithm hmac512 = Algorithm.HMAC512(keyStr);
+    return JWT.create()
+        .withSubject(userId)
+        .withIssuer("QuizzerBackend")
+        .withIssuedAt(now)
+        .withExpiresAt(now.plusMillis(JWT_REFRESH_TOKEN_VALIDITY.toMillis()))
         .sign(hmac512);
   }
 }

--- a/src/main/java/edu/ntnu/fullstack/prosjekt/quizzer/controllers/TokenController.java
+++ b/src/main/java/edu/ntnu/fullstack/prosjekt/quizzer/controllers/TokenController.java
@@ -88,7 +88,7 @@ public class TokenController {
 
       return ResponseEntity.ok(tokens);
     } catch (JWTVerificationException exception){
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid refresh token");
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid refresh token");
     }
   }
 

--- a/src/main/java/edu/ntnu/fullstack/prosjekt/quizzer/services/impl/UserServiceImpl.java
+++ b/src/main/java/edu/ntnu/fullstack/prosjekt/quizzer/services/impl/UserServiceImpl.java
@@ -7,6 +7,7 @@ import edu.ntnu.fullstack.prosjekt.quizzer.mappers.Mapper;
 import edu.ntnu.fullstack.prosjekt.quizzer.repositories.UserRepository;
 import edu.ntnu.fullstack.prosjekt.quizzer.services.UserService;
 import lombok.extern.java.Log;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,10 +59,16 @@ public class UserServiceImpl implements UserService {
    */
   @Override
   public Boolean checkCredentials(LoginDto userToBeChecked) {
-    //TODO: fikse litt exception handling
-    UserEntity userEntity = findEntityByUsername(userToBeChecked.getUsername());
-    return passwordEncoder.matches(userToBeChecked.getPassword(),
-            userEntity.getPassword());
+    try {
+      UserEntity userEntity = findEntityByUsername(userToBeChecked.getUsername());
+
+      if (userEntity == null) {
+        throw new UsernameNotFoundException("User not found with username: " + userToBeChecked.getUsername());
+      }
+      return passwordEncoder.matches(userToBeChecked.getPassword(), userEntity.getPassword());
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
Refactor token controller to now generate a pair of tokens, one access and one refresh token.

Also added endpoint '/refresh' to refresh an access token with a valid refresh token.

Added exception handling for checkCredentials as well.